### PR TITLE
Allow to run python MCP servers

### DIFF
--- a/src/commands/tool.ts
+++ b/src/commands/tool.ts
@@ -51,18 +51,21 @@ export default class Tool extends Command {
     
     //console.log(propsObject);
 
+    const isNodePackage = server.startsWith('@');
+    const command = isNodePackage ? (process.platform === "win32" ? "cmd" : "npx") : "uvx";
+    const args = isNodePackage ? (process.platform === "win32" ? [
+      "/c",
+      "npx",
+      "-y",
+      server
+    ] : [
+      "-y",
+      server
+    ]) : [server];
+
     const transport = new StdioClientTransport({
-      //command: process.platform === "win32" ? "npx.cmd" : "npx",
-      command: process.platform === "win32" ? "cmd" : "npx",
-      args: process.platform === "win32" ? [
-        "/c",
-        "npx",
-        "-y",
-        server
-      ] : [
-        "-y",
-        server
-      ]
+      command,
+      args
     });
 
     const client = new Client(

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -23,18 +23,21 @@ export default class Tools extends Command {
     // Assert that argv is a string array.
     const stringArgs = argv as string[]
 
+    const isNodePackage = stringArgs[0].startsWith('@');
+    const command = isNodePackage ? (process.platform === 'win32' ? 'cmd' : 'npx') : 'uvx';
+    const args = isNodePackage ? (process.platform === 'win32' ? [
+      "/c",
+      "npx",
+      "-y",
+      ...stringArgs
+    ] : [
+      "-y",
+      ...stringArgs
+    ]) : stringArgs;
+
     const transport = new StdioClientTransport({
-      //command: process.platform === "win32" ? "npx.cmd" : "npx",
-      command: process.platform === "win32" ? "cmd" : "npx",
-      args: process.platform === "win32" ? [
-        "/c",
-        "npx",
-        "-y",
-        ...stringArgs
-      ] : [
-        "-y",
-        ...stringArgs
-      ]
+      command,
+      args
     });
 
     const client = new Client(


### PR DESCRIPTION
Fixes #1

If "@" is the prefix of the MCP server, use npx, if not, assume a python server and use uvx.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mcpgod/cli/pull/2?shareId=d4a40301-d0d5-408e-b25e-3aaea86835b1).