### PR TITLE
Publish to npm on merge

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        with:
+          node-version: latest
       - name: Check if version already exists
         id: version-check
         run: |
@@ -56,3 +58,20 @@ jobs:
           commit: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           skipIfReleaseExists: true
+      - name: Install dependencies
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm install
+      - name: Build
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run build
+      - name: Prepare package
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run prepack
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+      - name: Cleanup package
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run postpack

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,8 +1,7 @@
 name: publish
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- build and publish to npm as part of push-to-main workflow
- allow manual npm publish via workflow dispatch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c55432b1c8321a94fc55c5d0ee563