### PR TITLE
Publish to npm on merge

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,14 @@
+name: lint workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1

--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -4,6 +4,7 @@ name: version, tag and github release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   release:
@@ -13,14 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        with:
+          node-version: latest
       - name: Check if version already exists
         id: version-check
         run: |
+          package_name=$(node -p "require('./package.json').name")
           package_version=$(node -p "require('./package.json').version")
-          exists=$(gh api repos/${{ github.repository }}/releases/tags/v$package_version >/dev/null 2>&1 && echo "true" || echo "")
+          gh_exists=$(gh api repos/${{ github.repository }}/releases/tags/v$package_version >/dev/null 2>&1 && echo "true" || echo "")
+          npm_exists=$(npm view "$package_name@$package_version" --json >/dev/null 2>&1 && echo "true" || echo "")
 
-          if [ -n "$exists" ];
-          then
+          if [ -n "$gh_exists" ] || [ -n "$npm_exists" ]; then
             echo "Version v$package_version already exists"
             echo "::warning file=package.json,line=1::Version v$package_version already exists - no release will be created. If you want to create a new release, please update the version in package.json and push again."
             echo "skipped=true" >> $GITHUB_OUTPUT
@@ -56,3 +60,20 @@ jobs:
           commit: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           skipIfReleaseExists: true
+      - name: Install dependencies
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm install
+      - name: Build
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run build
+      - name: Prepare package
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run prepack
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+      - name: Cleanup package
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run postpack

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,8 +1,7 @@
 name: publish
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ Run the CLI in development mode:
 ./bin/dev
 ```
 
+## Publishing
+
+Automatic publishing is handled by the `version, tag and github release` workflow. A new npm version is published whenever a version bump is merged into the `main` branch. The workflow can also be triggered manually from the **Actions** tab.
+
+To enable publishing, set the following repository secrets:
+
+- `NPM_TOKEN` – authentication token for npm.
+- `GH_EMAIL` and `GH_USERNAME` – used by the README update step.
+
+Once the secrets are configured, pushing a new version or running the workflow manually will build the project, create a GitHub release and publish the package to npm.
+
 ## Contributing
 
 Contributions are always welcome! To contribute:


### PR DESCRIPTION
## Summary
- build and publish to npm as part of push-to-main workflow
- allow manual npm publish via workflow dispatch
- check npm registry before publishing and lint workflow files
- document publishing secrets

## Testing
- `npm test`
- `npx actionlint` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_684c55432b1c8321a94fc55c5d0ee563