### PR TITLE
Publish to npm on merge

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,21 @@
+name: actionlint
+
+on:
+  # run only when workflow files change
+  pull_request:
+    paths: ['.github/workflows/**']
+  push:
+    branches: [main]
+    paths:   ['.github/workflows/**']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # installs the actionlint binary and scans .github/workflows
+      - name: Lint GitHub Actions
+        uses: eifinger/actionlint-action@v1
+        # with:
+        #   version: "v1.7.7"   # ⇐ uncomment to pin an exact linter version

--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -4,6 +4,7 @@ name: version, tag and github release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   release:
@@ -13,14 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        with:
+          node-version: latest
       - name: Check if version already exists
         id: version-check
         run: |
+          package_name=$(node -p "require('./package.json').name")
           package_version=$(node -p "require('./package.json').version")
-          exists=$(gh api repos/${{ github.repository }}/releases/tags/v$package_version >/dev/null 2>&1 && echo "true" || echo "")
+          gh_exists=$(gh api repos/${{ github.repository }}/releases/tags/v$package_version >/dev/null 2>&1 && echo "true" || echo "")
+          npm_exists=$(npm view "$package_name@$package_version" --json >/dev/null 2>&1 && echo "true" || echo "")
 
-          if [ -n "$exists" ];
-          then
+          if [ -n "$gh_exists" ] || [ -n "$npm_exists" ]; then
             echo "Version v$package_version already exists"
             echo "::warning file=package.json,line=1::Version v$package_version already exists - no release will be created. If you want to create a new release, please update the version in package.json and push again."
             echo "skipped=true" >> $GITHUB_OUTPUT
@@ -56,3 +60,20 @@ jobs:
           commit: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           skipIfReleaseExists: true
+      - name: Install dependencies
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm install
+      - name: Build
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run build
+      - name: Prepare package
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run prepack
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+      - name: Cleanup package
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: npm run postpack

--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -18,20 +18,23 @@ jobs:
           node-version: latest
       - name: Check if version already exists
         id: version-check
+        shell: bash
         run: |
-          package_name=$(node -p "require('./package.json').name")
-          package_version=$(node -p "require('./package.json').version")
-          gh_exists=$(gh api repos/${{ github.repository }}/releases/tags/v$package_version >/dev/null 2>&1 && echo "true" || echo "")
-          npm_exists=$(npm view "$package_name@$package_version" --json >/dev/null 2>&1 && echo "true" || echo "")
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
 
-          if [ -n "$gh_exists" ] || [ -n "$npm_exists" ]; then
-            echo "Version v$package_version already exists"
-            echo "::warning file=package.json,line=1::Version v$package_version already exists - no release will be created. If you want to create a new release, please update the version in package.json and push again."
-            echo "skipped=true" >> $GITHUB_OUTPUT
+          gh_exists="$(gh api \
+              "repos/${{ github.repository }}/releases/tags/v${package_version}" \
+              >/dev/null 2>&1 && echo 'true' || echo '')"
+
+          npm_exists="$(npm view "${package_name}@${package_version}" --json \
+              >/dev/null 2>&1 && echo 'true' || echo '')"
+
+          if [[ -n "$gh_exists" || -n "$npm_exists" ]]; then
+            echo "::warning file=package.json,line=1::Version v${package_version} already exists—skipping release."
+            echo "skipped=true"  >>"${GITHUB_OUTPUT}"
           else
-            echo "Version v$package_version does not exist. Creating release..."
-            echo "skipped=false" >> $GITHUB_OUTPUT
-            echo "tag=v$package_version" >> $GITHUB_OUTPUT
+            echo "skipped=false" >>"${GITHUB_OUTPUT}"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,8 +1,7 @@
 name: publish
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -145,6 +145,25 @@ Run the CLI in development mode:
 ./bin/dev
 ```
 
+## Publishing
+
+Automatic publishing is handled by the `version, tag and github release` workflow. A new npm version is published whenever a version bump is merged into the `main` branch. The workflow can also be triggered manually from the **Actions** tab.
+
+To enable publishing, set the following repository secrets:
+
+- `NPM_TOKEN` – authentication token for npm.
+- `GH_EMAIL` and `GH_USERNAME` – used by the README update step.
+
+Once the secrets are configured, pushing a new version or running the workflow manually will build the project, create a GitHub release and publish the package to npm.
+
+### Linting workflows
+
+Before committing changes to workflows, you can lint them locally:
+
+```sh
+npm run lint:workflows
+```
+
 ## Contributing
 
 Contributions are always welcome! To contribute:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-config-oclif": "^6",
         "eslint-config-prettier": "^10",
         "mocha": "^10",
+        "node-actionlint": "^1.2.2",
         "oclif": "^4",
         "shx": "^0.3.3",
         "ts-node": "^10",
@@ -8372,6 +8373,21 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-actionlint": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/node-actionlint/-/node-actionlint-1.2.2.tgz",
+      "integrity": "sha512-BUPYscLEoeKiLrWb7uFLsgDECtSgBMFOUTSL2N0EfMaVohty5DnubPDpQJnuVw7Rt11h2s+QIzg9rnNJSUCLmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "chalk": "^4.1.1",
+        "fast-glob": "^3.2.7"
+      },
+      "bin": {
+        "node-actionlint": "bin/node-actionlint.js"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "oclif": "^4",
     "shx": "^0.3.3",
     "ts-node": "^10",
-    "typescript": "^5"
+    "typescript": "^5",
+    "node-actionlint": "^1.2.2"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -62,7 +63,8 @@
     "prepack": "oclif manifest && oclif readme",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "coverage": "c8 --reporter=lcov --reporter=text npm test",
-    "version": "oclif readme && git add README.md"
+    "version": "oclif readme && git add README.md",
+    "lint:workflows": "node-actionlint '.github/workflows/**/*.yml'"
   },
   "types": "dist/index.d.ts"
 }


### PR DESCRIPTION
## Summary
- build and publish to npm as part of push-to-main workflow
- allow manual npm publish via workflow dispatch
- check npm registry before publishing and lint workflow files
- document publishing secrets
- fix actionlint workflow
- add local actionlint runner

## Testing
- `npm test`
- `npm run lint:workflows`
- `npx node-actionlint .github/workflows/onPushToMain.yml`


------
https://chatgpt.com/codex/tasks/task_e_684c55432b1c8321a94fc55c5d0ee563