### PR TITLE
Fix release workflow output

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -23,6 +23,8 @@ jobs:
           package_name="$(node -p "require('./package.json').name")"
           package_version="$(node -p "require('./package.json').version")"
 
+          echo "tag=v${package_version}" >>"${GITHUB_OUTPUT}"
+
           gh_exists="$(gh api \
               "repos/${{ github.repository }}/releases/tags/v${package_version}" \
               >/dev/null 2>&1 && echo 'true' || echo '')"


### PR DESCRIPTION
## Summary
- ensure release workflow outputs a tag for the release step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca7851c44832189f75f94cdcb2f8a